### PR TITLE
chore: remove deprecated plugins, fix bugs, improve keybindings

### DIFF
--- a/elisp/base-extensions.el
+++ b/elisp/base-extensions.el
@@ -17,16 +17,15 @@
 ;; https://github.com/emacs-dashboard/emacs-dashboard
 (use-package dashboard
   :init
-  (progn
-    (setq initial-buffer-choice (lambda () (get-buffer-create "*dashboard*")))
-    (setq dashboard-items              '((projects  . 7)
-					 (recents   . 10)
-					 (bookmarks . 7))
-	  dashboard-set-navigator      t
-	  dashboard-set-file-icons     t
-	  dashboard-set-heading-icons  t
-	  dashboard-startup-banner     'logo
-	  dashboard-week-agenda        nil))
+  (setq initial-buffer-choice  (lambda () (get-buffer-create "*dashboard*"))
+        dashboard-items         '((projects  . 7)
+                                  (recents   . 10)
+                                  (bookmarks . 7))
+        dashboard-set-navigator     t
+        dashboard-set-file-icons    t
+        dashboard-set-heading-icons t
+        dashboard-startup-banner    'logo
+        dashboard-week-agenda       nil)
   :config
   (dashboard-setup-startup-hook))
 
@@ -37,7 +36,7 @@
   (setq ediff-window-setup-function        'ediff-setup-windows-plain)
   (setq ediff-split-window-function        'split-window-horizontally)
   (setq-default ediff-highlight-all-diffs  'nil)
-  (setq ediff-diff-options "               -w"))
+  (setq ediff-diff-options "-w"))
 
 ;; Expand region increases the selected region by semantic units. Just keep pressing the key
 ;; until it selects what you want.
@@ -67,29 +66,35 @@
   (set-face-attribute 'helm-selection nil :background "#FBFFC8" :foreground "#04134B")
   (setq helm-split-window-in-side-p     t
         helm-split-window-default-side  'below
-	helm-idle-delay                 0.0
-	helm-input-idle-delay           0.01
-	helm-quick-update               t
-	helm-ff-skip-boring-files       t
-	helm-ag-insert-at-point         'symbol)
+        helm-input-idle-delay           0.01
+        helm-ff-skip-boring-files       t)
   :bind (("M-x"     . helm-M-x)
-	 ("C-c C-m" . helm-M-x)
-	 ("C-c C-f" . helm-find-files)
-	 ("C-x C-f" . helm-find-files)
-	 ("C-c h"   . helm-command-prefix)
-	 :map helm-command-map
-	 (("a" . helm-projectile-ag)
-	  ("d" . helm-do-ag)
-	  ("f" . helm-find-files)
-	  ;("g" . helm-projectile-grep)
-	  ("g" . helm-browse-project)
+         ("C-x C-f" . helm-find-files)
+         ("C-x b"   . helm-mini)
+         ("M-y"     . helm-show-kill-ring)
+         ("C-c h"   . helm-command-prefix)
+         :map helm-command-map
+         (("a" . helm-projectile-ag)
+          ("b" . helm-filtered-bookmarks)
+          ("d" . helm-do-ag)
+          ;; ("g" . helm-projectile-grep)
+          ("g" . helm-browse-project)
+          ("i" . helm-semantic-or-imenu)
           ("k" . helm-show-kill-ring)
           ("m" . helm-mini)
           ("o" . helm-occur)
-	  ;("s" . helm-swoop)
-	  ("v" . helm-projectile))
+          ("r" . helm-resume)
+          ;; ("s" . helm-swoop)
+          ("v" . helm-projectile))
          :map helm-map
-         ("<tab>"   . helm-execute-persistent-action)))
+         ("<tab>" . helm-execute-persistent-action)
+         ("C-z"   . helm-execute-persistent-action)))
+
+;; helm-ag configuration.
+;; https://github.com/emacsorphanage/helm-ag
+(use-package helm-ag
+  :custom
+  (helm-ag-insert-at-point 'symbol))
 
 ;; Show flycheck errors with helm.
 ;; https://github.com/yasuyk/helm-flycheck
@@ -137,10 +142,14 @@
   (lsp-modeline-code-actions-enable t)        ;; Modeline code actions
   (lsp-signature-auto-activate nil)           ;; Signature help documentation
   (lsp-signature-render-documentation nil)    ;; Signature help documentation
+  (lsp-eldoc-render-all t)                    ;; Display all info from document/onHover
 
-  ;; Display all of the info returned by document/onHover. If this is set to nil,
-  ;; eldoc will show only the symbol information.
-  (lsp-eldoc-render-all t)
+  :bind (:map lsp-mode-map
+         ("C-c l r" . lsp-rename)
+         ("C-c l a" . lsp-execute-code-action)
+         ("C-c l f" . lsp-format-buffer)
+         ("C-c l d" . lsp-describe-thing-at-point)
+         ("C-c l l" . lsp-ui-flycheck-list))
 
   :config
   (add-hook 'lsp-mode-hook 'lsp-ui-mode))
@@ -156,7 +165,7 @@
                                               ;; symbol to show the doc
   (lsp-ui-doc-show-with-mouse t)              ;; When non-nil, move the mouse pointer
                                               ;; over a symbol to show the doc
-  (lsp-ui-peek-always-show -1)
+  (lsp-ui-peek-always-show t)
   (lsp-ui-sideline-show-hover t)
   (lsp-ui-sideline-show-code-actions t))
 
@@ -164,11 +173,13 @@
 ;; Emacs package.
 ;; https://magit.vc/
 (use-package magit
-  :config
   :bind
   ("C-c m b" . magit-branch-and-checkout)
   ("C-c m c" . magit-commit)
+  ("C-c m d" . magit-diff-unstaged)
   ("C-c m e" . magit-ediff-resolve)
+  ("C-c m f" . magit-fetch)
+  ("C-c m l" . magit-log-current)
   ("C-c m p" . magit-push)
   ("C-c m r" . magit-rebase-interactive)
   ("C-c m s" . magit-status)
@@ -198,13 +209,14 @@
 (use-package org
   :config
   (setq org-directory           "~/Nextcloud/Documents/org/"
-        org-default-notes-file  (concat org-directory "/mw-tasks.org"))
+        org-default-notes-file  (concat org-directory "mw-tasks.org"))
 ;; 	   org-todo-keywords       '((sequence "☛ TODO(t)" "|" "<img draggable="false" role="img" class="emoji" alt="✔" src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/svg/2714.svg"> DONE(d)")
 ;; 			    (sequence "⚑ WAITING(w)" "|")
 ;; 			    (sequence "|" "✘ CANCELED(c)")))
   :bind
   ("C-c o s" . org-store-link)
-  ("C-c o a" . org-agenda))
+  ("C-c o a" . org-agenda)
+  ("C-c o c" . org-capture))
 
 ;; This package implements a modern style for your Org buffers using font locking
 ;; and text properties. The package styles headlines, keywords, tables and source
@@ -242,7 +254,7 @@
 	  ("C-c r o" . org-id-get-create)
           ("C-c r t" . org-roam-tag-add)))
   :config
-  (org-roam-setup))
+  (org-roam-db-autosync-mode))
 
 ;; org-projectile provides functions for the creation of org-mode TODOs that are
 ;; associated with projectile projects.
@@ -252,14 +264,6 @@
   (org-projectile-per-project)
   (setq org-projectile-per-project-filepath "todo.org"
 	org-agenda-files (append org-agenda-files (org-projectile-todo-files))))
-
-;; Prettify headings and plain lists in Org mode. This package is a direct
-;; descendant of ‘org-bullets’, with most of the code base completely rewritten.
-(use-package org-superstar
-  :config
-  (add-hook 'org-mode-hook
-	    (lambda ()
-	      (org-superstar-mode 1))))
 
 ;; This Emacs library provides a global mode which displays ugly form feed
 ;; characters as tidy horizontal rules.
@@ -289,7 +293,7 @@
 ;; https://www.emacswiki.org/emacs/RecentFiles
 (use-package recentf
   :config
-  (setq recentf-save-file (recentf-expand-file-name "~/.emacs.d/private/cache/recentf"))
+  (setq recentf-save-file (expand-file-name "~/.emacs.d/private/cache/recentf"))
   (recentf-mode 1))
 
 ;; Minor mode for Emacs that deals with parens pairs and tries to be smart about it.

--- a/elisp/base-global-keys.el
+++ b/elisp/base-global-keys.el
@@ -4,7 +4,6 @@
 
 (global-set-key (kbd "C-c C-o")
 		(lambda () (interactive) (find-file "~/org/mw-tasks.org")))
-(global-set-key (kbd "C-c C-c") 'org-capture)
 
 ;; Duplicate current line (or region)
 (global-set-key (kbd "C-c d") 'duplicate-current-line-or-region)

--- a/elisp/base.el
+++ b/elisp/base.el
@@ -2,7 +2,7 @@
 ;; Choose either melpa-stable or bleedinge-edge melpa
 ;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
-(add-to-list 'package-archives '("org"   . "http://orgmode.org/elpa/") t)
+
 (package-initialize)
 
 ;; use-package to simplify the config file
@@ -36,14 +36,14 @@
       custom-file                         "~/.emacs.d/.custom.el"
       ;; http://ergoemacs.org/emacs/emacs_stop_cursor_enter_prompt.html
       minibuffer-prompt-properties
-      '(read-only t point-entered minibuffer-avoid-prompt face minibuffer-prompt)
+      '(read-only t cursor-intangible t face minibuffer-prompt)
 
       ;; Disable non selected window highlight
       cursor-in-non-selected-windows      nil
       highlight-nonselected-windows       nil
       ;; PATH
       exec-path                           (append exec-path '("/usr/local/bin/"))
-      x-select-enable-clipboard           t
+      select-enable-clipboard             t
       use-package-always-ensure           t
       inhibit-compacting-font-caches      t
       ;; automatically open sym-linked files
@@ -79,6 +79,8 @@
       auto-save-timeout                   20     ; number of seconds idle time before auto-save (default: 30)
       auto-save-interval                  200    ; number of keystrokes between auto-saves (default: 300)
       )
+
+(add-hook 'minibuffer-setup-hook #'cursor-intangible-mode)
 
 (fset 'yes-or-no-p 'y-or-n-p)
 (global-auto-revert-mode t)

--- a/elisp/lang-elixir.el
+++ b/elisp/lang-elixir.el
@@ -1,10 +1,7 @@
-(use-package alchemist
-  :config
-  (add-hook 'elixir-mode-hook 'alchemist-mode))
-
 (use-package elixir-mode
   :config
   ;; Create a buffer-local hook to run elixir-format on save, only when we enable elixir-mode.
+  (add-hook 'elixir-mode-hook 'lsp-deferred)
   (add-hook 'elixir-mode-hook
             (lambda () (add-hook 'before-save-hook 'elixir-format nil t)))
   (add-hook 'elixir-format-hook (lambda ()

--- a/elisp/lang-go.el
+++ b/elisp/lang-go.el
@@ -6,41 +6,21 @@
   ;; ;; Use goimports instead of go-fmt
   ;; (setq gofmt-command "goimports")
   (add-hook 'go-mode-hook 'company-mode)
-  ;; Call Gofmt before saving
-  (add-hook 'before-save-hook 'gofmt-before-save)
+  (add-hook 'go-mode-hook 'flycheck-mode)
   (add-hook 'go-mode-hook 'setup-go-mode-compile)
   (add-hook 'go-mode-hook 'lsp-deferred)
   (add-hook 'go-mode-hook #'smartparens-strict-mode)
+  ;; Run gofmt on save, buffer-locally so it only affects Go files
+  (add-hook 'go-mode-hook
+            (lambda ()
+              (add-hook 'before-save-hook 'gofmt-before-save nil t)))
   (add-hook 'go-mode-hook (lambda ()
 			     (local-set-key (kbd "C-c C-r") 'go-remove-unused-imports)))
   (add-hook 'go-mode-hook (lambda ()
-			     (local-set-key (kbd "C-c C-g") 'go-goto-imports)))
-  (add-hook 'go-mode-hook (lambda ()
-			    (set (make-local-variable 'company-backends) '(company-go))
-			    (company-mode))))
-
-(use-package company-go
-  :after go-mode
-  :config
-  (setq tab-width 4)
-  (setq indent-tabs-mode 1)
-  :bind (:map go-mode-map
-	      ;; Godef jump key binding
-	      ("M-." . godef-jump)
-	      ("M-*" . pop-tag-mark)))
-
-(use-package flycheck
-  :config
-  (add-hook 'go-mode-hook 'flycheck-mode))
+			     (local-set-key (kbd "C-c C-g") 'go-goto-imports))))
 
 (use-package flycheck-golangci-lint
-  :hook (go-mode . flycheck-golangci-lint-setup)) ;; the same as :init + add-hook
-
-(use-package go-eldoc
-  :config
-  (add-hook 'go-mode-hook 'go-eldoc-setup))
-
-(use-package go-guru)
+  :hook (go-mode . flycheck-golangci-lint-setup))
 
 (defun setup-go-mode-compile ()
   ;; Customize compile command to run go build

--- a/elisp/lang-javascript.el
+++ b/elisp/lang-javascript.el
@@ -8,12 +8,6 @@
   (add-hook 'js2-mode-hook 'color-identifiers-mode)
   (add-hook 'web-mode-hook 'color-identifiers-mode))
 
-(use-package ac-js2
-  :config
-  (add-hook 'js2-mode-hook 'ac-js2-mode)
-  (add-hook 'web-mode-hook 'ac-js2-mode)
-  (add-to-list 'company-backends 'ac-js2-company))
-
 (use-package smartparens
   :config
   (require 'smartparens-config)

--- a/elisp/lang-python.el
+++ b/elisp/lang-python.el
@@ -1,34 +1,16 @@
 (setq exec-path (append exec-path '("~/.pyenv/bin")))
 
-(use-package py-autopep8)
+;; lsp-pyright provides fast Python type checking and completion via Pyright.
+;; https://github.com/emacs-lsp/lsp-pyright
+(use-package lsp-pyright
+  :hook (python-mode . (lambda ()
+                         (require 'lsp-pyright)
+                         (lsp-deferred))))
 
-(use-package blacken)
-
-(use-package elpy
-  :init
-  (add-to-list 'auto-mode-alist '("\\.py$" . python-mode))
-  :config
-  (setq elpy-rpc-backend "jedi")
-  (add-hook 'python-mode-hook 'py-autopep8-enable-on-save)
-  (add-hook 'python-mode-hook
-	    (lambda ()
-	      (setq indent-tabs-mode t)
-	      (setq tab-width 4)
-	      (setq python-indent-offset 4)))
-  (setq elpy-modules (delq 'elpy-module-flymake elpy-modules))
-  (add-hook 'elpy-mode-hook 'flycheck-mode)
-  :bind (:map elpy-mode-map
-	      ("M-." . elpy-goto-definition)
-	      ("M-," . pop-tag-mark)))
-
-;; (use-package focus
-;;   :config
-;;   (add-hook 'focus-mode-to-thing '(python-mode . paragaph)))
-
-(use-package python
-  :mode ("\\.py" . python-mode)
-  :config
-  (elpy-enable))
+;; Black formatter for Python.
+;; https://github.com/proofit404/blacken
+(use-package blacken
+  :hook (python-mode . blacken-mode))
 
 (use-package pip-requirements
   :config

--- a/elisp/lang-rust.el
+++ b/elisp/lang-rust.el
@@ -3,7 +3,7 @@
 ;; https://github.com/kwrooijen/cargo.el
 (use-package cargo
   :config
-  (add-hook 'rust-mode-hook 'cargo-minor-mode))
+  (add-hook 'rustic-mode-hook 'cargo-minor-mode))
 
 ;; This Flycheck extension configures Flycheck automatically for the current Cargo project.
 ;; https://github.com/flycheck/flycheck-rust

--- a/elisp/lang-terraform.el
+++ b/elisp/lang-terraform.el
@@ -1,7 +1,5 @@
 ;; Major mode of Terraform configuration file
 ;; https://github.com/syohex/emacs-terraform-mode
-(use-package terraform-mode
-  :config
-  (setq terraform-packages '(terraform-mode)))
+(use-package terraform-mode)
 
 (provide 'lang-terraform)


### PR DESCRIPTION
## Summary

A comprehensive cleanup of the Emacs configuration based on an audit of all plugins and keybindings. Changes are grouped below for easy review.

---

## 🗑️ Deprecated / Removed plugins

| File | Change |
|---|---|
| `lang-elixir` | Remove `alchemist` (unmaintained since 2019); wire `elixir-mode` to `lsp-deferred` instead |
| `lang-go` | Remove `company-go` (depends on dead `gocode`), `go-eldoc`, `go-guru` — all covered by `lsp-mode`/gopls |
| `lang-python` | Replace `elpy` + `py-autopep8` with `lsp-pyright` + `blacken` for a consistent LSP setup |
| `lang-javascript` | Remove `ac-js2` (legacy `auto-complete` backend) |
| `base-extensions` | Remove `org-superstar` (redundant with `org-modern`) |
| `base` | Remove deprecated `org` ELPA archive (`http://orgmode.org/elpa/`) |

---

## 🐛 Bug fixes

| File | Bug | Fix |
|---|---|---|
| `base-extensions/recentf` | `recentf-expand-file-name` does not exist → load-time error | → `expand-file-name` |
| `lang-go` | `gofmt-before-save` was on the global `before-save-hook`, running on every file | → moved inside `go-mode-hook` as buffer-local |
| `base-extensions/ediff` | `ediff-diff-options` had 15 stray leading spaces before `-w` | → `"-w"` |
| `lang-terraform` | `terraform-packages` is not a real variable — dead no-op code | → removed |
| `base-extensions/lsp-ui` | `lsp-ui-peek-always-show -1` — `-1` is truthy but misleading | → explicit `t` |
| `base-extensions/org` | `org-default-notes-file` had a double slash from trailing `/` dir + leading `/` filename | → removed leading `/` from filename |
| `lang-rust` | `cargo` hooked onto `rust-mode-hook` but config uses `rustic` which replaces `rust-mode` | → `rustic-mode-hook` |

---

## ⚠️ Deprecated settings

| File | Setting | Fix |
|---|---|---|
| `base` | `point-entered` in `minibuffer-prompt-properties` (removed in Emacs 25) | → `cursor-intangible t` + hook |
| `base` | `x-select-enable-clipboard` (renamed in Emacs 25) | → `select-enable-clipboard` |
| `base-extensions/org-roam` | `org-roam-setup` (deprecated in org-roam v2) | → `org-roam-db-autosync-mode` |

---

## ⌨️ Keybinding improvements

### LSP — new global bindings under `C-c l`
| Binding | Command |
|---|---|
| `C-c l r` | `lsp-rename` |
| `C-c l a` | `lsp-execute-code-action` |
| `C-c l f` | `lsp-format-buffer` |
| `C-c l d` | `lsp-describe-thing-at-point` |
| `C-c l l` | `lsp-ui-flycheck-list` |

### Magit — missing common commands added
| Binding | Command |
|---|---|
| `C-c m d` | `magit-diff-unstaged` |
| `C-c m f` | `magit-fetch` |
| `C-c m l` | `magit-log-current` |

### Org-capture — moved off conflicting binding
- `C-c C-c` → `org-capture` **removed** (conflicted with org-mode itself, magit, and many major modes)
- `C-c o c` → `org-capture` **added** alongside existing `C-c o s` / `C-c o a`

### Helm — see previous cleanup
- Removed obsolete `helm-idle-delay`, `helm-quick-update`
- Moved `helm-ag-insert-at-point` to its own `helm-ag` block
- Removed redundant `C-c C-m` and `C-c C-f` bindings
- Added `C-x b` (helm-mini), `M-y` (kill-ring), `C-c h b/i/r`, `C-z` in helm-map

---

## 🧹 Minor cleanup

- `magit`: removed empty `:config` block
- `dashboard`: removed unnecessary `progn` wrapper in `:init`
- `lang-go`: removed redundant `(use-package flycheck)` re-declaration