### PR TITLE
Fix Emacs startup errors

### DIFF
--- a/elisp/base-extensions.el
+++ b/elisp/base-extensions.el
@@ -90,11 +90,11 @@
          ("<tab>" . helm-execute-persistent-action)
          ("C-z"   . helm-execute-persistent-action)))
 
-;; helm-ag configuration.
-;; https://github.com/emacsorphanage/helm-ag
-(use-package helm-ag
-  :custom
-  (helm-ag-insert-at-point 'symbol))
+;; helm-ag was removed from MELPA; use helm's built-in ag support instead.
+;; helm-do-grep-ag (bound in helm-command-map) provides equivalent functionality.
+(with-eval-after-load 'helm-grep
+  (setq helm-grep-ag-command "ag --line-numbers -S --hidden --color %s %s %s"
+        helm-grep-ag-pipe-cmd-switches '("--color")))
 
 ;; Show flycheck errors with helm.
 ;; https://github.com/yasuyk/helm-flycheck

--- a/elisp/lang-javascript.el
+++ b/elisp/lang-javascript.el
@@ -35,7 +35,7 @@
   :init
   (setq-default tab-width                     2
                 js2-basic-indent              2
-                js2-basic-offset              2
+                js-indent-level               2
                 js2-auto-indent-p             t
                 js2-cleanup-whitespace        t
                 js2-concat-multiline-strings  'eol


### PR DESCRIPTION
Fixes two errors shown on startup:

## Changes

### Replace `helm-ag` with helm's built-in ag support
`helm-ag` is no longer available on MELPA. Replaced with a `with-eval-after-load` block that configures `helm-grep-ag-command` to use the locally installed `ag`. Use `M-x helm-do-grep-ag` for ag searches.

### Fix `js2-basic-offset` defvaralias warning
In newer versions of `js2-mode`, `js2-basic-offset` is aliased to `js-indent-level`. Setting it via `setq-default` before the alias is established causes:
```
⛔ Warning (defvaralias): Overwriting value of 'js2-basic-offset' by aliasing to 'js-indent-level'
```
Fixed by replacing `js2-basic-offset` with `js-indent-level` directly.