### PR TITLE
Add GitHub Copilot via copilot.el

### DIFF
--- a/elisp/base-extensions.el
+++ b/elisp/base-extensions.el
@@ -13,6 +13,19 @@
   :config
   (add-hook 'after-init-hook 'global-company-mode))
 
+;; GitHub Copilot for Emacs. Requires Node.js >= 18.
+;; https://github.com/copilot-emacs/copilot.el
+(use-package copilot
+  :vc (:url "https://github.com/copilot-emacs/copilot.el"
+       :rev :newest
+       :branch "main")
+  :hook (prog-mode . copilot-mode)
+  :bind (:map copilot-completion-map
+         ("<tab>"   . copilot-accept-completion)
+         ("TAB"     . copilot-accept-completion)
+         ("C-TAB"   . copilot-accept-completion-by-word)
+         ("C-<tab>" . copilot-accept-completion-by-word)))
+
 ;; An extensible emacs startup screen showing you what’s most important.
 ;; https://github.com/emacs-dashboard/emacs-dashboard
 (use-package dashboard


### PR DESCRIPTION
## Summary
- Installs `copilot.el` directly from `copilot-emacs/copilot.el` upstream via `use-package :vc`
- Hooks `copilot-mode` into all `prog-mode` buffers
- Tab / C-Tab accept full / per-word completion suggestions

## Notes
- Requires Node.js >= 18 (already in place locally via nvm)
- First load will prompt for `M-x copilot-install-server` and `M-x copilot-login`

## Test plan
- [ ] Open a `prog-mode` buffer after pulling; verify `copilot-mode` is active in the modeline
- [ ] Confirm Tab accepts a suggestion when one is displayed
- [ ] No startup errors from `emacs --batch -l init.el`

🤖 Generated with [Claude Code](https://claude.com/claude-code)