### PR TITLE
Add Claude Code IDE integration (claude-code-ide + vterm)

### DIFF
--- a/elisp/base-extensions.el
+++ b/elisp/base-extensions.el
@@ -13,6 +13,21 @@
   :config
   (add-hook 'after-init-hook 'global-company-mode))
 
+;; Terminal emulator used by claude-code-ide as its backend.
+;; Compiles a small C module on first install (cmake + libtool required).
+;; https://github.com/akermu/emacs-libvterm
+(use-package vterm)
+
+;; Claude Code IDE integration via MCP — bidirectional bridge between
+;; Claude Code CLI and Emacs (buffers, selection, LSP, project, diagnostics).
+;; https://github.com/manzaltu/claude-code-ide.el
+(use-package claude-code-ide
+  :vc (:url "https://github.com/manzaltu/claude-code-ide.el"
+       :rev :newest)
+  :bind ("C-c c" . claude-code-ide-menu)
+  :config
+  (claude-code-ide-emacs-tools-setup))
+
 ;; An extensible emacs startup screen showing you what’s most important.
 ;; https://github.com/emacs-dashboard/emacs-dashboard
 (use-package dashboard


### PR DESCRIPTION
## Summary
- Adds [`claude-code-ide.el`](https://github.com/manzaltu/claude-code-ide.el) — bidirectional MCP bridge between the Claude Code CLI and Emacs
- Adds [`vterm`](https://github.com/akermu/emacs-libvterm) as the required terminal backend
- Binds `C-c c` to `claude-code-ide-menu` (transient with start / stop / continue / resume / list-sessions / toggle)
- Enables `claude-code-ide-emacs-tools-setup` so Claude can use xref / project / tree-sitter / imenu through MCP

## Why this and not a plain terminal wrapper
Unlike running `claude` in a vterm, this package implements the same MCP protocol Claude Code uses in VS Code. That means Claude sees the active buffer, current selection, project boundaries, and Flycheck/Flymake diagnostics — and can apply edits through an ediff workflow instead of just dumping suggested diffs into chat.

## Prerequisites (already satisfied locally)
- Emacs 28.1+ (running 30.2)
- `claude` CLI on PATH
- `cmake` + `libtool` (vterm builds a small C module on first load)

## Test plan
- [ ] `emacs --batch -l init.el` exits cleanly with no errors
- [ ] `M-x claude-code-ide-check-status` reports CLI is installed
- [ ] `C-c c` opens the transient menu
- [ ] Starting a session via the menu opens a Claude side window on the right
- [ ] Selecting a region + sending a prompt shows the selection in Claude's context

🤖 Generated with [Claude Code](https://claude.com/claude-code)